### PR TITLE
diode-private-preview: update README and examples

### DIFF
--- a/diode-private-preview/README.md
+++ b/diode-private-preview/README.md
@@ -38,8 +38,7 @@ export DIODE_API_KEY=<provided during Diode private preview program onboarding>
 All scripts have an optional flags:
 
 ```
---target TARGET  the target address of the Diode server (without http:// or https://)
---tls_verify     enable TLS verification (default: True)
+--target TARGET  the target address of the Diode server (default: grpc://localhost:8081)
 --apply          apply the changes (default: False)
 ```
 

--- a/diode-private-preview/README.md
+++ b/diode-private-preview/README.md
@@ -6,7 +6,7 @@
 
 Pre-requisites:
 
-* Python >= 3.7
+* Python >= 3.10
 
 1. Create a virtual environment and activate it:
 

--- a/diode-private-preview/examples/csv/main.py
+++ b/diode-private-preview/examples/csv/main.py
@@ -3,22 +3,25 @@ import csv
 import sys
 
 from netboxlabs.diode.sdk import DiodeClient
-from netboxlabs.diode.sdk.ingester import (
-    Device,
-    Entity
-)
+from netboxlabs.diode.sdk.ingester import Device, Entity
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--target", type=str, default="localhost:8081", help="the target address of the Diode server")
-    parser.add_argument("--tls_verify", action="store_false", default=True, help="enable TLS verification")
-    parser.add_argument("--apply", action="store_true", default=False, help="apply the changes")
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="grpc://localhost:8081",
+        help="the target address of the Diode server",
+    )
+    parser.add_argument(
+        "--apply", action="store_true", default=False, help="apply the changes"
+    )
     args = parser.parse_args()
 
     entities = []
 
-    with open('inventory.csv', 'r') as file:
+    with open("inventory.csv", "r") as file:
         reader = csv.reader(file)
         header = next(reader)
 
@@ -26,12 +29,12 @@ def main():
             entities.append(
                 Entity(
                     device=Device(
-                        name=row[header.index('Device_Name')],
-                        serial=row[header.index('Serial_Number')],
-                        site=row[header.index('Site_Name')],
-                        role=row[header.index('Device_Type')],
-                        device_type=row[header.index('Device_Model')],
-                        manufacturer=row[header.index('Vendor')],
+                        name=row[header.index("Device_Name")],
+                        serial=row[header.index("Serial_Number")],
+                        site=row[header.index("Site_Name")],
+                        role=row[header.index("Device_Type")],
+                        device_type=row[header.index("Device_Model")],
+                        manufacturer=row[header.index("Vendor")],
                     )
                 )
             )
@@ -41,8 +44,9 @@ def main():
         print(f"INFO: entities to ingest: {entities}")
         sys.exit(0)
 
-    with DiodeClient(target=args.target, app_name="csv-parser", app_version="0.0.1",
-                     tls_verify=args.tls_verify) as client:
+    with DiodeClient(
+        target=args.target, app_name="csv-parser", app_version="0.0.1"
+    ) as client:
         response = client.ingest(entities=entities)
         if response.errors:
             print(f"FAIL: response errors: {response.errors}")


### PR DESCRIPTION
- bump python minimum version to 3.10
- remove `tls_verify` flag (as being determined from `grpc://` or `grpcs://` schemes of a target)
- add `grpc://localhost:8081` as default target
- formatting