### PR TITLE
fix: diode-private-preview - opening files

### DIFF
--- a/diode-private-preview/examples/cisco_ios/main.py
+++ b/diode-private-preview/examples/cisco_ios/main.py
@@ -35,6 +35,7 @@ def parse_cisco_config(config_file: str, site: str = "Site A") -> list[Entity]:
     """
 
     file_path = os.path.join(os.path.dirname(__file__), config_file)
+
     parse = CiscoConfParse(file_path, syntax="ios")
 
     # Extract device name (hostname), end processing if not found

--- a/diode-private-preview/examples/cisco_ios/main.py
+++ b/diode-private-preview/examples/cisco_ios/main.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import sys
 
 from ciscoconfparse2 import CiscoConfParse
@@ -33,7 +34,8 @@ def parse_cisco_config(config_file: str, site: str = "Site A") -> list[Entity]:
                     such as 'hostname' or 'version'.
     """
 
-    parse = CiscoConfParse(config_file, syntax="ios")
+    file_path = os.path.join(os.path.dirname(__file__), config_file)
+    parse = CiscoConfParse(file_path, syntax="ios")
 
     # Extract device name (hostname), end processing if not found
     if parse.find_objects(r"^hostname"):

--- a/diode-private-preview/examples/containerlab/main.py
+++ b/diode-private-preview/examples/containerlab/main.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import sys
 
 import yaml
@@ -25,7 +26,9 @@ def parse_clab_config(config_file: str) -> list[Entity]:
     """
 
     entities = []
-    with open(config_file, "r") as file:
+    file_path = os.path.join(os.path.dirname(__file__), config_file)
+
+    with open(file_path, "r") as file:
         data = yaml.safe_load(file)
 
         # Set the site name

--- a/diode-private-preview/examples/csv/main.py
+++ b/diode-private-preview/examples/csv/main.py
@@ -1,5 +1,6 @@
 import argparse
 import csv
+import os
 import sys
 
 from netboxlabs.diode.sdk import DiodeClient
@@ -21,7 +22,9 @@ def main():
 
     entities = []
 
-    with open("inventory.csv", "r") as file:
+    file_path = os.path.join(os.path.dirname(__file__), "inventory.csv")
+
+    with open(file_path, "r") as file:
         reader = csv.reader(file)
         header = next(reader)
 


### PR DESCRIPTION
Fix opening files to read relative to the location of `main.py`