### PR TITLE
Fixed ContainerLab networking for restarts

### DIFF
--- a/netbox-discovery-quickstart/4_start_network.sh
+++ b/netbox-discovery-quickstart/4_start_network.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
 set -euo pipefail
 
+# Check if all required environment variables are set
+REQUIRED_VARS=("DOCKER_NETWORK" "DOCKER_SUBNET")
+
+# Create the docker network if it doesn't already exist
+if ! docker network inspect "$DOCKER_NETWORK" &>/dev/null; then
+    echo "Creating Docker network: $DOCKER_NETWORK with subnet: $DOCKER_SUBNET"
+    docker network create \
+        --driver=bridge \
+        --subnet="$DOCKER_SUBNET" \
+        "$DOCKER_NETWORK"
+else
+    echo "Docker network '$DOCKER_NETWORK' already exists."
+fi
+
 # Check if directory parameter is passed
 if [ $# -eq 0 ]; then
   echo "Usage: $0 <network_directory>"

--- a/netbox-discovery-quickstart/network/ios.clab.yml
+++ b/netbox-discovery-quickstart/network/ios.clab.yml
@@ -2,10 +2,11 @@ name: discovery-quickstart-cisco
 
 mgmt:
   network: discovery-quickstart
+  ipv4-subnet: 172.24.0.0/24
 
 topology:
   nodes:
     ios1:
       kind: vr-csr
       image: mrmrcoleman/vr-csr:17.03.06
-      mgmt-ipv4: 172.24.0.100
+      mgmt-ipv4: 172.24.0.102


### PR DESCRIPTION
Pushed the Docker network logic into `4_start_network.sh` so users can restart labs and switch between the `srl` and `ios` labs without issues.