### PR TITLE
Fix .gitignore to include prometheus config templates

### DIFF
--- a/autocon4-workshop/.gitignore
+++ b/autocon4-workshop/.gitignore
@@ -2,6 +2,6 @@ diode/
 gitea/
 netbox-docker/
 network/clab-workshop/
-prometheus/
+/prometheus/
 environment
 diode_creds

--- a/autocon4-workshop/config-templates/prometheus/alerts/httpcheck.yaml
+++ b/autocon4-workshop/config-templates/prometheus/alerts/httpcheck.yaml
@@ -1,0 +1,36 @@
+groups:
+  - name: httpcheck_alerts
+    interval: 15s
+    rules:
+      # Alert when HTTP check doesn't return 2xx
+      - alert: WebServer_NotReachable
+        expr: httpcheck_status{http_url="http://192.168.2.2", http_status_class="2xx"} == 0
+        labels:
+          severity: critical
+          team: workshop
+        annotations:
+          summary: "HTTP check failed for {{ $labels.http_url }}"
+          description: "HTTP check for {{ $labels.http_url }} is not responding with 2xx status."
+
+      # Alert when HTTP check has errors
+      - alert: WebServer_HttpCheckError
+        expr: httpcheck_error{http_url="http://192.168.2.2"} == 1
+        labels:
+          severity: critical
+          team: workshop
+        annotations:
+          summary: "HTTP check error for {{ $labels.http_url }}"
+          description: "HTTP check for {{ $labels.http_url }} returned error message: {{ $labels.error_message }}."
+
+      # Alert when no metrics received
+      - alert: HttpCheck_NoMetricsReceived
+        expr: |
+          absent(httpcheck_status) == 1
+          or
+          absent(httpcheck_duration_milliseconds) == 1
+        labels:
+          severity: critical
+          team: workshop
+        annotations:
+          summary: "HTTP check metrics missing"
+          description: "Critical: no httpcheck metrics have been received."

--- a/autocon4-workshop/config-templates/prometheus/docker-compose.yaml
+++ b/autocon4-workshop/config-templates/prometheus/docker-compose.yaml
@@ -1,0 +1,26 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yaml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+      - '--web.enable-remote-write-receiver'
+      - '--query.lookback-delta=30s'
+    volumes:
+      - ./prometheus.yaml:/etc/prometheus/prometheus.yaml:ro
+      - ./alerts:/etc/prometheus/alerts
+      - prometheus-data:/prometheus
+    ports:
+      - "9090:9090"
+    restart: unless-stopped
+    healthcheck:
+        test: ["CMD-SHELL", "promtool check healthy || exit 1"]
+        interval: 30s
+        timeout: 10s
+        retries: 3
+        start_period: 40s
+volumes:
+  prometheus-data:

--- a/autocon4-workshop/config-templates/prometheus/prometheus.yaml
+++ b/autocon4-workshop/config-templates/prometheus/prometheus.yaml
@@ -1,0 +1,6 @@
+global:
+  evaluation_interval: 10s
+
+# Load alert rules
+rule_files:
+  - '/etc/prometheus/alerts/*.yaml'


### PR DESCRIPTION
- Changed prometheus/ to /prometheus/ in .gitignore to only ignore the runtime directory
- Added prometheus config templates to config-templates/prometheus/
- Includes docker-compose.yaml, prometheus.yaml, and alerts/httpcheck.yaml
- These templates are needed by 6_start_prometheus.sh script