### PR TITLE
Add troubleshooting step for missing Nokia SRLinux Ansible collection

### DIFF
--- a/autocon4-workshop/modules/module_5/README.md
+++ b/autocon4-workshop/modules/module_5/README.md
@@ -110,6 +110,14 @@ It's a unique identifier for the branch. The Ansible script uses it to query the
 
 Now for the magic moment - let's deploy your NetBox intent to the actual network devices!
 
+### Install Required Ansible Collection
+
+First, ensure the Nokia SRLinux Ansible collection is installed:
+
+```bash
+ansible-galaxy collection install nokia.srlinux
+```
+
 ### Run the Deployment
 
 From your workshop directory, run:


### PR DESCRIPTION
## Summary
- Added proactive installation step for Nokia SRLinux Ansible collection in Module 5
- Prevents users from encountering missing collection error during deployment

## Changes
- Added "Install Required Ansible Collection" subsection before the deployment command
- Included the command: `ansible-galaxy collection install nokia.srlinux`
- This ensures the collection is installed before running the deployment

## Test plan
- [x] Verify the installation step appears in the correct location (before the deployment command)
- [x] Confirm the command is accurate and complete
- [x] Ensure the flow is logical and proactive rather than reactive