### PR TITLE
Fix reset_network.sh: source diode_creds to avoid DIODE_CLIENT_ID error

### DIFF
--- a/autocon5-workshop/reset_network.sh
+++ b/autocon5-workshop/reset_network.sh
@@ -5,6 +5,7 @@ cd "$(dirname "$0")"
 
 set -a
 source ./1_set_envvars.sh
+[ -f ./diode_creds ] && source ./diode_creds
 set +a
 
 ./8_start_network.sh network/workshop.clab.yaml


### PR DESCRIPTION
## Summary

`reset_network.sh` was only sourcing `1_set_envvars.sh`, not `diode_creds`. Participants who opened a fresh terminal session before running the network reset at the end of Module 1 would hit:

```
Error: Required environment variable 'DIODE_CLIENT_ID' is not set.
```

The fix sources `diode_creds` automatically if it exists, making the script self-contained regardless of terminal session history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)