### PR TITLE
Fix step consistency and missing content across Modules 4, 5 and 6

### DIFF
--- a/autocon5-workshop/modules/module_4/README.md
+++ b/autocon5-workshop/modules/module_4/README.md
@@ -516,7 +516,9 @@ With CHECK 3 passing on both devices, the interface configuration is validated a
 1. Navigate to **Branching** → **Branches**
 2. Click on your `module-4-srl-config` branch
 3. Click **Merge**
-4. Confirm the merge
+4. Check the **Commit Changes** checkbox
+5. **Merge Strategy**: leave it set to `Iterative`
+6. Click **Merge Branch**
 
 Your interface and IP address changes are now on the main branch — the authoritative source of truth for the network.
 

--- a/autocon5-workshop/modules/module_5/README.md
+++ b/autocon5-workshop/modules/module_5/README.md
@@ -379,7 +379,8 @@ The rendered configs now include both interfaces and OSPF. Push them to the devi
 1. Navigate to **Customization** → **Scripts** → **Trigger EDA Event**
 2. **Event Type**: `Push Device Config`
 3. **Branch**: select `module-5-ospf-config`
-4. Click **Run Script**
+4. Leave **Target Device** blank
+5. Click **Run Script**
 
 Watch the Ansible output as it applies the full config — interfaces, OSPF instance, router IDs, area membership, and passive interfaces — to both devices from a single trigger.
 

--- a/autocon5-workshop/modules/module_5/README.md
+++ b/autocon5-workshop/modules/module_5/README.md
@@ -452,7 +452,20 @@ Expected output:
 
 Each neighbor at `FULL` state confirms a stable OSPF adjacency. The routes show that each router has learned the other's stub network via OSPF — exactly what enables the web server to be reachable from the orb agent.
 
-## Step 8: Merge the Branch
+## Step 8: Confirm in Grafana
+
+With all six checks passing, the network is fully configured and OSPF is routing traffic end-to-end. Open Grafana to confirm that observability agrees:
+
+1. Open `https://grafana-<YOUR_ID>.autocon5.netboxlabs.tech`
+2. Navigate to **Dashboards** → **Workshop Network Observability**
+3. Look at the **Web Server Status** panel
+
+You should see 🟢 **Reachable** — the Orb agent can now reach the web server via the OSPF-routed path through srl1 and srl2.
+
+> [!NOTE]
+> It may take up to a minute for the Orb agent's next health check to register. If it still shows red, wait a moment and refresh.
+
+## Step 9: Merge the Branch
 
 The network is working and the validation report confirms it. Merge the branch to promote the OSPF configuration to main.
 

--- a/autocon5-workshop/modules/module_6/README.md
+++ b/autocon5-workshop/modules/module_6/README.md
@@ -335,7 +335,22 @@ Once the script completes, run **Branch Change Summary** again to review the upd
 2. Select **Branch**: `module-6-discovery`
 3. Click **Run Script**
 
-The output should show **no meaningful changes** — which is exactly what you want to see. The network now matches main, so there's nothing left to report. Discovery has confirmed the drift is resolved.
+The output should show **no meaningful changes** to interfaces or routing — the disabled interface is back up and the network state matches main. Discovery has confirmed the drift is resolved.
+
+> [!NOTE]
+> **You may see 3 newly created IPAM prefixes — this is expected.**
+>
+> Diode infers prefix objects from the IP addresses it discovers on device interfaces. Because NetBox tracks IP addresses (e.g. `10.0.0.1/30` on `ethernet-1/1.0`) but not necessarily the parent prefix objects (`10.0.0.0/30`), discovery may surface these as new:
+>
+> ```text
+> Object Type    Name
+> -------------  --------------
+> IPAM | prefix  10.0.0.0/30
+> IPAM | prefix  192.168.1.0/30
+> IPAM | prefix  192.168.2.0/30
+> ```
+>
+> These aren't drift — they're Diode filling in IPAM data that wasn't explicitly modelled. You can safely discard the `module-6-discovery` branch without merging them, or merge the branch to add them to your source of truth as accurate prefix records. Either is a valid choice.
 
 > [!NOTE]
 > **The Next Step: Closing the Loop Fully**


### PR DESCRIPTION
## Summary

Three small fixes to improve step consistency across modules:

- **Module 4, Step 7**: Replace vague "Confirm the merge" with the explicit Commit Changes checkbox, Merge Strategy, and Merge Branch steps — matching Modules 2 and 5
- **Module 5, Step 6**: Add missing "Leave Target Device blank" instruction — consistent with Steps 7 and 8 in the same module
- **Module 5, Step 8** (new): Add Grafana reachability check after validation — the visual confirmation that OSPF is routing end-to-end, consistent with Module 1

## Test plan
- [x] Module 4 Step 7 merge instructions match Module 2 and Module 5
- [x] Module 5 Step 6 has the Target Device blank note
- [x] Module 5 Step 8 Grafana check appears before the merge step

🤖 Generated with [Claude Code](https://claude.com/claude-code)