### PR TITLE
Module 1: add SR Linux credentials tip before verification SSH step

### DIFF
--- a/autocon5-workshop/modules/module_1/README.md
+++ b/autocon5-workshop/modules/module_1/README.md
@@ -358,6 +358,12 @@ Exit srl2 by pressing `Ctrl+D`.
 
 Now for the real test: Can srl1 reach the web server through the OSPF-routed path?
 
+> [!TIP]
+> **Nokia SR Linux Credentials**
+>
+> - Username: `admin`
+> - Password: `NokiaSrl1!`
+
 SSH into srl1:
 
 ```bash


### PR DESCRIPTION
Adds a `[!TIP]` callout with SR Linux credentials before the SSH into srl1 step in the verification section, matching the pattern already used earlier in the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)