### PR TITLE
chore(codeowners): remove @rboucher-me

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @richbibby @mrmrcoleman @rboucher-me
+*       @richbibby @mrmrcoleman


### PR DESCRIPTION
Removes @rboucher-me from CODEOWNERS. The account is no longer a member of the netboxlabs org, so GitHub already ignores the entry; this keeps review routing accurate as part of offboarding hygiene. Found in an org-wide CODEOWNERS sweep; same cleanup as netboxlabs/orb-pro#998.