### PR TITLE
netbox-discovery-quickstart: add macOS support via Lima VM, fix NetBox/Diode plugin version mismatch

### DIFF
--- a/netbox-discovery-quickstart/0_macos_create_vm.sh
+++ b/netbox-discovery-quickstart/0_macos_create_vm.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# NetBox Discovery Quickstart — macOS bootstrap
+#
+# This quickstart relies on ContainerLab, which has no native macOS support,
+# and its Nokia SR Linux lab images, which are published x86_64-only. This
+# script creates a Lima-managed Ubuntu VM that satisfies both requirements —
+# a real Linux host, with a genuine x86_64 kernel so SR Linux boots cleanly
+# (a native arm64 VM with per-process amd64 emulation is NOT enough; SR
+# Linux's system daemons boot-loop under it) — and drops you into a shell
+# inside it so you can continue with the rest of the quickstart exactly as
+# documented in README.md, starting from "Clone the repo".
+#
+# Run this ON YOUR MAC, not inside any VM:
+#   ./0_macos_create_vm.sh
+#
+# Override sizing if you like, e.g.:
+#   VM_CPUS=6 VM_MEMORY_GIB=8 ./0_macos_create_vm.sh
+# but note that fewer than ~8-10 CPUs / 12GiB RAM has been observed to cause
+# Device Discovery's bulk NetBox writes to time out under emulation.
+
+VM_NAME="${VM_NAME:-netbox-quickstart}"
+VM_CPUS="${VM_CPUS:-11}"
+VM_MEMORY_GIB="${VM_MEMORY_GIB:-16}"
+VM_DISK_GIB="${VM_DISK_GIB:-60}"
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "This script is for macOS only. On Linux, just follow the main README directly."
+  exit 1
+fi
+
+if ! command -v brew &> /dev/null; then
+  echo "Error: Homebrew is required (https://brew.sh) to install Lima."
+  exit 1
+fi
+
+if ! command -v limactl &> /dev/null; then
+  echo "--- Installing Lima ---"
+  brew install lima
+fi
+
+# Apple Silicon needs the QEMU driver + additional guest agent to run an
+# x86_64 guest at all (the default 'vz' driver only supports native-arch
+# guests).
+if [[ "$(uname -m)" == "arm64" ]]; then
+  if ! brew list lima-additional-guestagents &> /dev/null; then
+    echo "--- Installing lima-additional-guestagents (x86_64 guest support on Apple Silicon) ---"
+    brew install lima-additional-guestagents
+  fi
+fi
+
+if limactl list --format '{{.Name}}' 2>/dev/null | grep -qx "$VM_NAME"; then
+  echo "--- VM '$VM_NAME' already exists, starting it ---"
+  limactl start "$VM_NAME"
+else
+  echo "--- Creating VM '$VM_NAME' (x86_64, ${VM_CPUS} CPUs, ${VM_MEMORY_GIB}GiB RAM, ${VM_DISK_GIB}GiB disk) ---"
+  limactl create --name="$VM_NAME" --arch=x86_64 \
+    --cpus="$VM_CPUS" --memory="$VM_MEMORY_GIB" --disk="$VM_DISK_GIB" \
+    template:ubuntu-25.04 --tty=false
+  echo "--- Starting VM '$VM_NAME' ---"
+  limactl start "$VM_NAME"
+fi
+
+VM_IP=$(limactl shell "$VM_NAME" -- bash -c "ip -4 addr show | grep -v '127.0.0.1' | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -1")
+
+echo
+echo "--- VM ready ---"
+echo "VM internal IP: $VM_IP"
+echo
+echo "Lima automatically forwards any port the VM listens on back to"
+echo "127.0.0.1 on your Mac, so once NetBox is up later in this guide you"
+echo "can always reach it at http://127.0.0.1:8000 from your Mac browser,"
+echo "regardless of the IP address used inside the VM."
+echo
+echo "Next steps — open a shell in the VM and continue the main README from"
+echo "'Clone the repo and go to the Discovery Quickstart':"
+echo
+echo "  limactl shell $VM_NAME"
+echo "  sudo mkdir -p /opt && sudo chown \$(whoami):\$(whoami) /opt && cd /opt"
+echo "  git clone https://github.com/netboxlabs/netbox-learning.git"
+echo "  cd netbox-learning/netbox-discovery-quickstart"
+echo "  ./0_install_host_tooling.sh"
+echo
+echo "When you reach 'Generate and export the necessary environment"
+echo "variables', use:"
+echo
+echo "  export MY_EXTERNAL_IP=$VM_IP"
+echo
+echo "Note: the 'su - quickstart' step won't accept password input"
+echo "non-interactively. If you're scripting the rest of this, grant"
+echo "passwordless sudo first:"
+echo
+echo "  echo 'quickstart ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/quickstart-nopasswd"
+echo "  sudo chmod 440 /etc/sudoers.d/quickstart-nopasswd"

--- a/netbox-discovery-quickstart/3_start_netbox.sh
+++ b/netbox-discovery-quickstart/3_start_netbox.sh
@@ -16,7 +16,13 @@ echo "--- Cloning NetBox Docker ---"
 echo
 
 # Clone netbox-docker
-git clone --branch 3.3.0 https://github.com/netbox-community/netbox-docker.git
+# NOTE: netbox-docker's release version and the NetBox image version it
+# pairs with must stay in lockstep with the Diode plugin's supported range.
+# 5.0.2 <-> netbox v4.6.7 <-> netboxlabs-diode-netbox-plugin==1.14.1 is a
+# verified-working combination (the plugin's min/max supported NetBox
+# version moves with each plugin release - if you bump the plugin version,
+# check its NetBoxDiodePluginConfig.min_version/max_version on PyPI first).
+git clone --branch 5.0.2 https://github.com/netbox-community/netbox-docker.git
 pushd netbox-docker
 
 echo
@@ -24,15 +30,15 @@ echo "--- Generating configuration files ---"
 echo
 
 cat <<EOF > Dockerfile-Plugins
-FROM netboxcommunity/netbox:v4.3.7
+FROM netboxcommunity/netbox:v4.6.7
 
-RUN uv pip install netboxlabs-diode-netbox-plugin
+RUN uv pip install netboxlabs-diode-netbox-plugin==1.14.1
 EOF
 
 cat <<EOF > docker-compose.override.yml
 services:
   netbox:
-    image: netbox:v4.3.7-plugins
+    image: netbox:v4.6.7-plugins
     pull_policy: never
     ports:
       - "${NETBOX_PORT}:8080"
@@ -46,15 +52,18 @@ services:
       SUPERUSER_NAME: "admin"
       SUPERUSER_PASSWORD: "admin"
     healthcheck:
+      # start_period is generous because on a resource-constrained or
+      # emulated host (e.g. a VM on Apple Silicon), first-run migrations
+      # for a fresh database can take upwards of 20-30 minutes.
       test: curl -f http://${MY_EXTERNAL_IP}:${NETBOX_PORT}/login/ || exit 1
-      start_period: 600s
+      start_period: 1800s
       timeout: 3s
       interval: 15s
   netbox-worker:
-    image: netbox:v4.3.7-plugins
+    image: netbox:v4.6.7-plugins
     pull_policy: never
   netbox-housekeeping:
-    image: netbox:v4.3.7-plugins
+    image: netbox:v4.6.7-plugins
     pull_policy: never
 EOF
 

--- a/netbox-discovery-quickstart/README.md
+++ b/netbox-discovery-quickstart/README.md
@@ -24,8 +24,26 @@ You will be able to run simple scripts to use both features of NetBox Discovery:
 > - The workshop can be run on a server or virtual machine with a public or private IP. Please see the additional step for private IP options below.
 > - We recommend using a machine with at least 4GB of RAM and 2 cores. If you're using a discount cloud or are going to run Cisco IOS images, we recommend at least 8GB of RAM and 4 cores.  
 > - The workshop has been tested on Ubuntu up to 25.04 (Plucky Puffin). It _should_ work on other Linux distros but if you hit any problems please create an [issue](https://github.com/netboxlabs/netbox-learning/issues) in GitHub  
-> - Unfortunately MacOS is not supported. The quickstart relies heavily on ContainerLab which does not have native support for MacOS  
+> - MacOS is not supported directly — ContainerLab (used later in this quickstart) has no native macOS support, and the Nokia SR Linux lab images are x86_64-only. If you're on a Mac, see **[Running on macOS](#running-on-macos)** below before continuing; everyone else can skip straight to cloning the repo.  
 
+
+## Running on macOS
+
+This quickstart needs a genuine Linux host, and specifically a genuine **x86_64** Linux kernel — not just an arm64 VM with per-process x86_64 emulation. (A native arm64 VM was tried first; the Nokia SR Linux lab images' system daemons boot-loop under QEMU's per-process binfmt emulation because they rely on kernel/ioctl behavior user-mode emulation can't provide. A full x86_64 guest, even though it's itself running under emulation on Apple Silicon, gives them a real x86_64 kernel and boots them cleanly.)
+
+A script is included to set this up for you using [Lima](https://lima-vm.io/) (requires [Homebrew](https://brew.sh)):
+
+```
+./0_macos_create_vm.sh
+```
+
+This installs Lima if needed, creates an x86_64 Ubuntu 25.04 VM sized for this workload (11 CPUs / 16GiB RAM / 60GiB disk by default — fewer CPUs has been observed to make Device Discovery's bulk writes to NetBox time out under emulation), and prints the next commands to run. Follow its output to open a shell in the VM, clone the repo, and continue with **every step below from "Install the required tooling on the host" onward, run inside that VM shell** — the rest of this README is identical whether you're on bare-metal Linux or in this VM.
+
+A couple of macOS/VM-specific notes that apply throughout the rest of this guide:
+
+- Lima automatically forwards any port the VM listens on back to `127.0.0.1` on your Mac. Once NetBox is running you can always reach it at `http://127.0.0.1:8000` from your Mac's browser, regardless of what `MY_EXTERNAL_IP` is set to inside the VM.
+- The `su - quickstart` step below expects an interactive password prompt (the account has none, so an empty-Enter normally suffices interactively). If you're driving this non-interactively, grant the `quickstart` user passwordless sudo first — `0_macos_create_vm.sh`'s output includes the exact command.
+- First-time NetBox startup (database migrations) can take considerably longer than "a few minutes" inside this VM — budget **20-30 minutes**, not 5. See [Troubleshooting](#troubleshooting) if it seems stuck.
 
 ### Clone the repo and go to the Discovery Quickstart
 
@@ -89,7 +107,7 @@ source 1_set_envvars.sh
 
 > [!TIP]
 >   
-> NetBox runs a lot of database migrations when starting up for the first time so this can take a few minutes  
+> NetBox runs a lot of database migrations when starting up for the first time so this can take a few minutes on bare-metal Linux — and considerably longer (20-30 minutes) inside the macOS VM described above  
 
 ```
 ./3_start_netbox.sh
@@ -293,6 +311,45 @@ First NetBox Discovery will load the environment and the policies we've defined 
 - Now click on the first device `srl1`. Here you can see that the `Device Type`, `Platform` and `Status` have all been set correctly.
 - Now click on the `Interfaces` tab for `srl1`. Now you'll see that all our our device interfaces have been successfully ingested into NetBox, with the correct administrative statuses which are called `Enabled` in NetBox.
 - Lastly, click on the top interface `ethernet-1/1`. Now you'll see that NetBox Discovery has correctly ingested the correct `MAC Address`, `MTU`, and `Speed/Duplex` for the interface.
+
+## Troubleshooting
+
+A few issues that can come up, particularly when running inside the macOS VM described above:
+
+**`netbox-docker-netbox-housekeeping-1` exits shortly after `3_start_netbox.sh` finishes.**
+This container can lose a startup race against Postgres on first boot and exit (`Exited (1)`). It's a periodic-maintenance service, not required for anything in this quickstart — just start it again if you want it running: `docker start netbox-docker-netbox-housekeeping-1`.
+
+**After stopping/restarting containers (e.g. after a VM reboot), Diode requests start failing with `502 Bad Gateway` or auth errors.**
+`diode-ingress-nginx-1` resolves its upstream container hostnames (like `diode-auth`) once and caches the IP; if a container it points to gets a new IP from a restart, nginx keeps routing to the stale address. Restart nginx to force it to re-resolve: `docker restart diode-ingress-nginx-1`.
+
+**Device Discovery's changes never seem to land in NetBox (`Devices` -> `Devices` stays empty), and `diode-diode-reconciler-1`'s logs show `bulk plan-apply` requests failing with a client-side timeout.**
+This means NetBox is genuinely processing the request (check `docker stats` — you'll likely see it pegged near 100% CPU) but too slowly to beat the reconciler's client timeout. This shows up specifically because Device Discovery's payload (~65 entities per device) is much heavier than Network Discovery's. On the macOS VM, give it more CPU:
+```
+limactl stop netbox-quickstart
+limactl edit netbox-quickstart --cpus 11 --memory 16
+limactl start netbox-quickstart
+```
+then restart any containers that didn't come back up on their own (`docker ps -a` to check, `docker start <name>` for anything `Exited`).
+
+**After fixing a failure and retrying discovery, some IPs/devices still never show up in NetBox — Diode's logs show them as `duplicate ingestion log` every time.**
+Diode dedupes ingested entities by a content-derived ID, and it does this regardless of whether the *first* attempt actually succeeded. If an earlier attempt failed (e.g. due to the timeout issue above) before you fixed the underlying problem, its entities are now permanently "seen" and will never be retried automatically — the discovery agent will keep re-sending the same content, and Diode will keep calling it a duplicate. Clear the stuck rows from Diode's own database (this is Diode's internal bookkeeping, not NetBox data) and then re-run discovery:
+```
+docker exec diode-postgres-1 psql -U diode -d diode -c "SELECT state, count(*) FROM ingestion_logs GROUP BY state;"
+# state 8 = stuck mid-apply, state 4 = failed — both block future retries of the same content
+docker exec diode-postgres-1 psql -U diode -d diode -c "DELETE FROM ingestion_logs WHERE state IN (4, 8);"
+```
+
+**Verifying data via the NetBox REST API yourself (rather than the UI) and getting `"Invalid v1 token"` even with a token you just created.**
+NetBox 4.6+ uses a new token format. A token's `.key` attribute alone is not a usable credential — capture the `.token` property at creation time and send it as `Authorization: Bearer nbt_<key>.<secret>` (not `Authorization: Token ...`, which is only for legacy 40-character v1 tokens):
+```
+docker exec netbox-docker-netbox-1 python3 /opt/netbox/netbox/manage.py shell -i python -c "
+from django.contrib.auth import get_user_model
+from users.models import Token
+admin = get_user_model().objects.get(username='admin')
+tok = Token(user=admin); tok.save()
+print('Authorization: Bearer nbt_' + tok.key + '.' + tok.token)
+"
+```
 
 ## Conclusion
 


### PR DESCRIPTION
## Summary

Adds macOS support to the NetBox Discovery quickstart, and fixes a real (platform-independent) version-compatibility bug hit along the way.

## Changes

**`0_macos_create_vm.sh` (new)**
ContainerLab has no native macOS support, and the Nokia SR Linux lab images are x86_64-only. A native arm64 Lima VM was tried first, but SR Linux's system daemons boot-loop under QEMU's per-process binfmt emulation — they need kernel/ioctl behavior that only a genuine x86_64 kernel provides. This script bootstraps a Lima-managed x86_64 Ubuntu 25.04 VM sized for the workload (11 CPUs / 16GiB RAM by default — fewer CPUs caused Device Discovery's bulk NetBox writes to time out under emulation) and prints the next commands to run inside it.

**`3_start_netbox.sh`**
Bumped `netbox-docker` from `3.3.0` (paired with NetBox v4.3.7) to `5.0.2` (paired with NetBox v4.6.7), and pinned the Diode plugin to `1.14.1`. The script previously installed the plugin unpinned, which now resolves to a release requiring NetBox >=4.4.10 — so on the pinned v4.3.7 base, the plugin silently failed to load (`Unable to load plugin netbox_diode_plugin: ... requires NetBox minimum version 4.4.10 (current: 4.3.7)`), and neither Network Discovery nor Device Discovery could actually reach NetBox. This isn't macOS-specific — anyone running the quickstart fresh right now would hit it. Also raised the NetBox healthcheck `start_period` from 600s to 1800s to match realistic first-migration timing on a freshly-provisioned host.

**`README.md`**
- New "Running on macOS" section explaining the above and pointing to `0_macos_create_vm.sh`.
- Notes on Lima's automatic port-forwarding, the non-interactive `su - quickstart` step, and realistic migration timing.
- New Troubleshooting section covering issues hit getting this working end-to-end:
  - `netbox-docker-netbox-housekeeping-1` exiting once on a benign first-boot race
  - Diode's nginx caching a stale upstream IP after container restarts (502s)
  - Device Discovery's bulk NetBox writes timing out under CPU-constrained emulation
  - Diode's ingestion-log dedup permanently blocking retries of previously-failed content (a footgun if you retry after fixing an earlier failure)
  - NetBox 4.6's new v2 API token format, for anyone scripting against the API directly

## Verification

Ran the full quickstart end-to-end on macOS (Apple Silicon) via the new Lima VM path: NetBox + Diode plugin load correctly, Network Discovery lands all expected IPs in IPAM, and Device Discovery lands both SR Linux devices in DCIM with correct Device Type/Platform/Status and full interface data (MAC address, MTU, speed) including the inter-device link `ethernet-1/1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)